### PR TITLE
[UART]  Fix write(buf, size) implementation

### DIFF
--- a/cores/arduino/Serial.cpp
+++ b/cores/arduino/Serial.cpp
@@ -37,6 +37,9 @@ void UART::begin(unsigned long baudrate) {
 	if (_serial == NULL) {
 		_serial = new mbed::RawSerial(tx, rx, baudrate);
 	}
+	if (rts != NC) {
+		_serial->set_flow_control(mbed::SerialBase::Flow::RTSCTS, rts, cts);
+	}
 	_serial->attach(mbed::callback(this, &UART::on_rx), mbed::SerialBase::RxIrq);
 }
 
@@ -84,11 +87,29 @@ UART::operator bool() {
 }
 
 #if SERIAL_HOWMANY > 0
-UART UART1(SERIAL1_TX, SERIAL1_RX);
+
+#ifdef SERIAL1_RTS
+UART UART1(SERIAL1_TX, SERIAL1_RX, SERIAL1_RTS, SERIAL1_CTS);
+#else
+UART UART1(SERIAL1_TX, SERIAL1_RX, NC, NC);
+#endif
+
 #if SERIAL_HOWMANY > 1
-UART UART2(SERIAL2_TX, SERIAL2_RX);
+
+#ifdef SERIAL2_RTS
+UART UART2(SERIAL2_TX, SERIAL2_RX, SERIAL2_RTS, SERIAL2_CTS);
+#else
+UART UART2(SERIAL2_TX, SERIAL2_RX, NC, NC);
+#endif
+
 #if SERIAL_HOWMANY > 2
-UART UART3(SERIAL3_TX, SERIAL3_RX);
+
+#ifdef SERIAL3_RTS
+UART UART1(SERIAL3_TX, SERIAL3_RX, SERIAL3_RTS, SERIAL3_CTS);
+#else
+UART UART1(SERIAL3_TX, SERIAL3_RX, NC, NC);
+#endif
+
 #endif
 #endif
 #endif

--- a/cores/arduino/Serial.cpp
+++ b/cores/arduino/Serial.cpp
@@ -77,6 +77,7 @@ size_t UART::write(uint8_t c) {
 	return ret == -1 ? 0 : 1;
 }
 
+#ifdef DEVICE_SERIAL_ASYNCH
 size_t UART::write(const uint8_t* c, size_t len) {
 
 	uint8_t* p = (uint8_t*)c;
@@ -98,6 +99,7 @@ size_t UART::write(const uint8_t* c, size_t len) {
 
 	return len;
 }
+#endif
 
 void UART::block_tx(int _a) {
 	_block = false;

--- a/cores/arduino/Serial.h
+++ b/cores/arduino/Serial.h
@@ -32,7 +32,7 @@ namespace arduino {
 
 class UART : public HardwareSerial {
 	public:
-		UART(int _tx, int _rx) : tx((PinName)_tx), rx((PinName)_rx) {};
+		UART(int _tx, int _rx, int _rts, int _cts) : tx((PinName)_tx), rx((PinName)_rx), rts((PinName)_rts), cts((PinName)_cts) {};
 		void begin(unsigned long);
 		void begin(unsigned long baudrate, uint16_t config);
 		void end();
@@ -48,7 +48,7 @@ class UART : public HardwareSerial {
 	private:
 		void on_rx();
 		mbed::RawSerial* _serial = NULL;
-		PinName tx, rx;
+		PinName tx, rx, rts, cts;
 		RingBufferN<256> rx_buffer;
 		uint8_t intermediate_buf[4];
 };

--- a/cores/arduino/Serial.h
+++ b/cores/arduino/Serial.h
@@ -41,12 +41,16 @@ class UART : public HardwareSerial {
 		int read(void);
 		void flush(void);
 		size_t write(uint8_t c);
-		//size_t write(const uint8_t*, size_t);
+		size_t write(const uint8_t*, size_t);
 		using Print::write; // pull in write(str) and write(buf, size) from Print
 		operator bool();
 
 	private:
 		void on_rx();
+		void block_tx(int);
+		bool _block;
+		// See https://github.com/ARMmbed/mbed-os/blob/f5b5989fc81c36233dbefffa1d023d1942468d42/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/serial_api.c#L76
+		const size_t WRITE_BUFF_SZ = 32;
 		mbed::RawSerial* _serial = NULL;
 		PinName tx, rx, rts, cts;
 		RingBufferN<256> rx_buffer;

--- a/cores/arduino/Serial.h
+++ b/cores/arduino/Serial.h
@@ -41,7 +41,9 @@ class UART : public HardwareSerial {
 		int read(void);
 		void flush(void);
 		size_t write(uint8_t c);
+		#ifdef DEVICE_SERIAL_ASYNCH
 		size_t write(const uint8_t*, size_t);
+		#endif
 		using Print::write; // pull in write(str) and write(buf, size) from Print
 		operator bool();
 


### PR DESCRIPTION
Fixes https://github.com/arduino/ArduinoCore-nRF528x-mbedos/issues/20

For devices that declare `DEVICE_SERIAL_ASYNCH` at mbed level use the async implementation and make it blocking (to be compliant with Arduino APIs) 

For devices without `DEVICE_SERIAL_ASYNCH` , fix `write(char)` implementation so it returns 0 when `putc()` returns -1 ; this way, the default Print overload works https://github.com/arduino/ArduinoCore-API/blob/namespace_arduino/api/Print.cpp#L31