### PR TITLE
Set PWMs state to DISABLE at init

### DIFF
--- a/variants/ARDUINO_NANO33BLE/variant.cpp
+++ b/variants/ARDUINO_NANO33BLE/variant.cpp
@@ -81,6 +81,18 @@ void initVariant() {
 
   digitalWrite(PIN_ENABLE_SENSORS_3V3, HIGH);
   digitalWrite(PIN_ENABLE_I2C_PULLUP, HIGH);
+ 
+  NRF_PWM_Type* PWM[] = {
+    NRF_PWM0, NRF_PWM1, NRF_PWM2
+#ifdef NRF_PWM3
+    ,NRF_PWM3
+#endif
+  };
+
+  for (int i = 0; i < (sizeof(PWM)/sizeof(PWM[0])); i++) {
+    PWM[i]->ENABLE = 0;
+    PWM[i]->PSEL.OUT[0] = 0xFFFFFFFFUL;
+  } 
 }
 
 #ifdef SERIAL_CDC


### PR DESCRIPTION
The PWMs state is ENABLED by MbedOS during startup, while some libraries (eg. Adafruit NeoPixel) will check for disabled state before using the PWMs. This fix resets the PWMs state to DISABLED at `initVariant` in order to let applications use the PWMs.