### PR TITLE
Update pins_arduino.h

### DIFF
--- a/variants/ARDUINO_NANO33BLE/pins_arduino.h
+++ b/variants/ARDUINO_NANO33BLE/pins_arduino.h
@@ -53,6 +53,23 @@ static const uint8_t A6  = PIN_A6;
 static const uint8_t A7  = PIN_A7;
 #define ADC_RESOLUTION 12
 
+// Digital pins
+// -----------
+#define D0   0
+#define D1   1
+#define D2   2
+#define D3   3
+#define D4   4
+#define D5   5
+#define D6   6
+#define D7   7
+#define D8   8
+#define D9   9
+#define D10  10
+#define D11  11
+#define D12  12
+#define D13  13
+
 /*
  * Serial interfaces
  */


### PR DESCRIPTION
Is there some reason why Arduino does not set the digital pins with defines? Unlike other Arduinos which use numbers for the main digital pins, on the Nano 33 BLE and BLE Sense the pins are labelled as D2, D3 etc.

