### PR TITLE
fix PDM pin order in declaration

### DIFF
--- a/libraries/PDM/src/PDM.h
+++ b/libraries/PDM/src/PDM.h
@@ -30,7 +30,7 @@
 class PDMClass
 {
 public:
-  PDMClass(int pwrPin, int clkPin, int dinPin);
+  PDMClass(int dinPin, int clkPin, int pwrPin);
   virtual ~PDMClass();
 
   int begin(int channels, long sampleRate);


### PR DESCRIPTION
The pin name in the declaration is not the same as class implementation.