### PR TITLE
analogWrite() range should be 0-255, not 0-256.

### DIFF
--- a/cores/arduino/wiring_analog.cpp
+++ b/cores/arduino/wiring_analog.cpp
@@ -40,7 +40,7 @@ static mbed::PwmOut* PinNameToPwmObj(PinName P) {
 
 void analogWrite(PinName pin, int val)
 {
-  float percent = (float)val/(float)(1 << write_resolution);
+  float percent = (float)val/(float)((1 << write_resolution)-1);
 #ifdef digitalPinToPwmObj
   mbed::PwmOut* pwm = PinNameToPwmObj(pin);
   if (pwm == NULL) {
@@ -57,7 +57,7 @@ void analogWrite(PinName pin, int val)
 
 void analogWrite(pin_size_t pin, int val)
 {
-  float percent = (float)val/(float)(1 << write_resolution);
+  float percent = (float)val/(float)((1 << write_resolution)-1);
 #ifdef digitalPinToPwmObj
   mbed::PwmOut* pwm = digitalPinToPwmObj(pin);
   if (pwm == NULL) {


### PR DESCRIPTION
See issue #74 

AnalogWrite() range was scaled from 0-256, rather than Arduino's 0-255 (8 bit) spec.

I patched this change into my Arduino board support package and ran my test program.  It makes the lights turn all the way on and off now.

(This is my first pull request through github, so please let me know if I can provide more information which would be helpful for you.)