### PR TITLE
Set default pinMode for CHANGE 

### DIFF
--- a/cores/arduino/Interrupts.cpp
+++ b/cores/arduino/Interrupts.cpp
@@ -69,7 +69,17 @@ void attachInterruptParam(pin_size_t interruptNum, voidFuncPtrParam func, PinSta
   digitalPinToInterruptObj(interruptNum) = irq;
   // Give a default pullup for the pin, since calling InterruptIn with PinMode is impossible
   if (digitalPinToGpio(interruptNum) == NULL) {
-    pinMode(interruptNum, mode == FALLING ? INPUT_PULLUP : INPUT_PULLDOWN);
+    switch(mode){
+      case FALLING:
+        pinMode(interruptNum, INPUT_PULLUP);
+        break;
+      case RISING:
+        pinMode(interruptNum, INPUT_PULLDOWN);
+        break;
+      default:
+        pinMode(interruptNum, INPUT);
+        break;
+    }
   }
 }
 

--- a/cores/arduino/Interrupts.cpp
+++ b/cores/arduino/Interrupts.cpp
@@ -69,16 +69,12 @@ void attachInterruptParam(pin_size_t interruptNum, voidFuncPtrParam func, PinSta
   digitalPinToInterruptObj(interruptNum) = irq;
   // Give a default pullup for the pin, since calling InterruptIn with PinMode is impossible
   if (digitalPinToGpio(interruptNum) == NULL) {
-    switch(mode){
-      case FALLING:
-        pinMode(interruptNum, INPUT_PULLUP);
-        break;
-      case RISING:
-        pinMode(interruptNum, INPUT_PULLDOWN);
-        break;
-      default:
-        pinMode(interruptNum, INPUT);
-        break;
+    if (mode == FALLING) {
+      pinMode(interruptNum, INPUT_PULLUP);
+    } else if (mode == RISING) {
+      pinMode(interruptNum, INPUT_PULLDOWN);
+    } else {
+      pinMode(interruptNum, INPUT);
     }
   }
 }


### PR DESCRIPTION
Use same if/else styling to set default pinMode to INPUT in case of non-RISING/FALLING interrupts.

Initially tried switch/case but this matched better, so please squash on commit.