### PR TITLE
analogWrite with negative value to delete pwm objects

### DIFF
--- a/cores/arduino/wiring_analog.cpp
+++ b/cores/arduino/wiring_analog.cpp
@@ -45,14 +45,22 @@ void analogWrite(pin_size_t pin, int val)
   if (pin >= PINS_COUNT) {
     return;
   }
-  float percent = (float)val/(float)((1 << write_resolution)-1);
   mbed::PwmOut* pwm = digitalPinToPwm(pin);
-  if (pwm == NULL) {
+  if ((pwm == NULL) && (val > 0)) {
     pwm = new mbed::PwmOut(digitalPinToPinName(pin));
     digitalPinToPwm(pin) = pwm;
     pwm->period_ms(2); //500Hz
+    float percent = (float)val/(float)((1 << write_resolution)-1);
+    pwm->write(percent);
+  } 
+  else if ((pwm != NULL) && (val < 0)) {
+    delete pwm;
+    digitalPinToPwm(pin) = NULL;
+  } 
+  else if ((pwm != NULL) && (val > 0)) {
+    float percent = (float)val/(float)((1 << write_resolution)-1);
+    pwm->write(percent);
   }
-  pwm->write(percent);
 }
 
 void analogWriteResolution(int bits)


### PR DESCRIPTION
This commit allows to deactivate an active PWM attached to a pin N by passing a negative value to the function `analogWrite(N, value)` .

Necessary fix in mbed-os:
Because of how [this mbed function](https://github.com/ARMmbed/mbed-os/blob/19e762298f9a020606f7358539bb653be0de8e4f/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/pinmap_ex.c#L307-L370) is implemented, there is the need to add a piece of code that sets `nordic_internal_pwm[index] == NC` when an active pwm is deinitialized (see [here](https://github.com/ARMmbed/mbed-os/blob/19e762298f9a020606f7358539bb653be0de8e4f/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_15_0/modules/nrfx/drivers/src/nrfx_pwm.c#L185) ). Otherwise, after having initialized all the 4 pwm instances, the `nordic_internal_pwm` array will be full. At this point, when a pwm is deactivated, its entry in the array will not be cleared. This is a problem because in this way when a new pwm is initialized, [here](https://github.com/ARMmbed/mbed-os/blob/468372e759a412d837fc51ecba66851ef34091d8/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/pwmout_api.c#L144), no pwm instance will be found free and the default instance (the last one) will be returned. This means that no matter what pwm is deactivated, the new init pwm will try to use the default pwm instance even if it is not free. This results in a failure.

test sketch:
```C++
void setup()
{}

void loop() {
    static unsigned long time = millis();
    static uint8_t analogValue = 0;
    if (millis() - time >= 2000) {
      time = millis();
      analogValue += 10; 
      if (analogValue >= 250)
        analogValue = 0;
      
      analogWrite(2, analogValue);
      analogWrite(3, analogValue);
      analogWrite(4, analogValue);
      analogWrite(5, analogValue);
      // deinit the last one 
      analogWrite(5, -1);
      // OK because the last pwm instance has been freed
      analogWrite(9, analogValue);
      // deinit a pwm with an instance that is not the last one
      analogWrite(2, -1);
      // Error: the last pwm instance is busy
      analogWrite(9, analogValue);
    }
}

```